### PR TITLE
Use same HDMI source name for InFocus as with Epson.

### DIFF
--- a/lib/infocus.py
+++ b/lib/infocus.py
@@ -27,7 +27,9 @@ import lib.errors
 # Remember to add new models to the settings.xml-file as well
 _valid_sources_ = {
         "IN72/IN74/IN76": {
-            "HDMI":      "0",
+            # Is HDMI in InFocus documentation and menu, but use HDMI1
+            # here to be compatible with Epson and value in settings.xml
+            "HDMI1":     "0",
             "MI-DA":     "1",
             "Component": "2",
             "S-Video":   "3",


### PR DESCRIPTION
This make sure the default value set in settings.xml is also
valid for InFocus projectors.