### PR TITLE
Reverse screensaver logic (save = off, active = on).

### DIFF
--- a/service.py
+++ b/service.py
@@ -100,11 +100,11 @@ class ProjectorMonitor(xbmc.Monitor):
 
     def onScreensaverActivated(self):
         if __addon__.getSetting("at_ss_start") == "true":
-            lib.commands.start()
+            lib.commands.stop()
 
     def onScreensaverDeactivated(self):
         if __addon__.getSetting("at_ss_shutdown") == "true":
-            lib.commands.stop()
+            lib.commands.start()
 
     def onSettingsChanged(self):
         if __addon__.getSetting("enabled") == "true":


### PR DESCRIPTION
Previously the projector would be turned on when the screen saver
kicked in, and off when the screen saver was finished.